### PR TITLE
Add support for `labelSource` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [Unreleased]
+### Changed
+- Update to model.js@0.7.0 and use `evaluateLabel()` to take advantage of `labelSource` option
+
 ## [0.6.1] - 2019-12-05
 ### Fixed
 - Update to `model.js` version 0.6.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -810,9 +810,9 @@
       }
     },
     "@cognitoforms/model.js": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@cognitoforms/model.js/-/model.js-0.6.1.tgz",
-      "integrity": "sha512-zuZgxSP3BT/2WWHbPsitLaP3J9oGfgcKGy8Anb0OmiUDKMfsfi2c6GK0COZUXjwi04CkupUKfstWo/2HtLYeGA=="
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cognitoforms/model.js/-/model.js-0.7.0.tgz",
+      "integrity": "sha512-WJGR+WJSf/Wek325x8Fj6di8dTVjlB2K/cE/L4/dJwu/1IBqDFamuZiHzneJfWjckbyHKDrjbv/h8COCRRqEhQ=="
     },
     "@jest/console": {
       "version": "24.3.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "webpack-cli": "^3.3.0"
   },
   "dependencies": {
-    "@cognitoforms/model.js": "^0.6.1",
+    "@cognitoforms/model.js": "^0.7.0",
     "vue": "^2.6.10",
     "vue-class-component": "^7.0.1",
     "vue-property-decorator": "^7.3.0"

--- a/src/source-path-adapter.ts
+++ b/src/source-path-adapter.ts
@@ -1,7 +1,7 @@
 import Vue from "vue";
 import { Component, Prop } from "vue-property-decorator";
 import { Entity } from "@cognitoforms/model.js"; // eslint-disable-line import/no-duplicates
-import { Property, isPropertyBooleanFunction, isPropertyBooleanFunctionAndOptions } from "@cognitoforms/model.js"; // eslint-disable-line import/no-duplicates
+import { Property, evaluateLabel, isPropertyBooleanFunction, isPropertyBooleanFunctionAndOptions } from "@cognitoforms/model.js"; // eslint-disable-line import/no-duplicates
 import { SourceAdapter, SourcePropertyAdapter, isSourceAdapter } from "./source-adapter";
 import { SourceOptionAdapter } from "./source-option-adapter";
 import { AllowedValuesRule } from "@cognitoforms/model.js"; // eslint-disable-line import/no-duplicates
@@ -66,7 +66,7 @@ export class SourcePathAdapter<TEntity extends Entity, TValue> extends Vue imple
 		let label = this.overrides ? this.overrides.label : null;
 		if (label === undefined || label === null) {
 			if (this.property.labelIsFormat) {
-				label = this.parent.value.toString(this.property.label);
+				label = evaluateLabel(this.property, this.parent.value);
 			}
 			else {
 				label = this.property.label;


### PR DESCRIPTION
- feat: Update to model.js@0.7.0 and use `evaluateLabel()` to take advantage of `labelSource` option