### PR TITLE
Avoid null errors in source adapter properties

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,3 +1,9 @@
+import { Entity, isEntityType } from "@cognitoforms/model.js";
+
+export function isEntity(obj): obj is Entity {
+	return obj && obj.meta && obj.meta.type && obj.meta.type.jstype && isEntityType(obj.meta.type.jstype);
+}
+
 export function getProp(obj: any, prop: string): any {
 	return obj[prop];
 }

--- a/src/source-adapter.ts
+++ b/src/source-adapter.ts
@@ -4,6 +4,9 @@ import { SourceItemAdapter } from "./source-item-adapter";
 import { SourceOptionAdapter } from "./source-option-adapter";
 import { Entity } from "@cognitoforms/model.js"; // eslint-disable-line import/no-duplicates
 import { PropertyPath } from "@cognitoforms/model.js"; // eslint-disable-line import/no-duplicates
+import { EntityType, ValueType } from "@cognitoforms/model.js"; // eslint-disable-line import/no-duplicates
+
+export type SourceType = ValueType | EntityType | ObjectConstructor;
 
 export interface SourceAdapterOverrides {
 	label?: string;
@@ -16,6 +19,8 @@ export interface SourceAdapter<TValue> {
 	readonly: boolean;
     value: TValue;
     displayValue: string;
+	type: SourceType;
+	isList: boolean;
 }
 
 export interface SourcePropertyAdapter<TValue> extends SourceAdapter<TValue> {

--- a/src/source-item-adapter.ts
+++ b/src/source-item-adapter.ts
@@ -1,9 +1,10 @@
 import Vue from "vue";
 import { Component, Prop, Watch } from "vue-property-decorator";
 import { Entity } from "@cognitoforms/model.js"; // eslint-disable-line import/no-duplicates
-import { SourceAdapter, isSourceAdapter, isSourcePropertyAdapter } from "./source-adapter";
+import { SourceAdapter, isSourceAdapter, isSourcePropertyAdapter, SourceType } from "./source-adapter";
 import { SourcePathAdapter, SourcePathOverrides } from "./source-path-adapter";
 import { ObservableArray, ArrayChangeType } from "@cognitoforms/model.js"; // eslint-disable-line import/no-duplicates
+import { isEntity } from "./helpers";
 
 @Component
 export class SourceItemAdapter<TEntity extends Entity, TValue> extends Vue implements SourceAdapter<TValue> {
@@ -15,14 +16,14 @@ export class SourceItemAdapter<TEntity extends Entity, TValue> extends Vue imple
 
 	@Prop(Object)
     overrides: SourcePathOverrides;
-    
+
     @Prop({ type: Boolean, default: false })
     suppressChangeTracking: boolean;
 
     isOrphaned: boolean = false;
 
     internalIndex: number = -1;
-    
+
     isSubscribedToSourceChanges: boolean = false;
 
     created(): void {
@@ -112,6 +113,18 @@ export class SourceItemAdapter<TEntity extends Entity, TValue> extends Vue imple
 		let list = this.parent.value;
 		let value = list[this.internalIndex];
 		return value as TValue;
+	}
+
+	get type(): SourceType {
+		// If possible, determine the type based on the actual entity instance
+		if (this.value && isEntity(this.value))
+			return this.value.meta.type.jstype;
+
+		return this.parent.type;
+	}
+
+	get isList(): boolean {
+		return false;
 	}
 
 	get displayValue(): string {

--- a/src/source-root-adapter.ts
+++ b/src/source-root-adapter.ts
@@ -1,7 +1,7 @@
 import Vue from "vue";
 import { Component, Prop } from "vue-property-decorator";
 import { Entity } from "@cognitoforms/model.js";
-import { SourceAdapter } from "./source-adapter";
+import { SourceAdapter, SourceType } from "./source-adapter";
 
 @Component
 export class SourceRootAdapter<TEntity extends Entity> extends Vue implements SourceAdapter<TEntity> {
@@ -12,6 +12,14 @@ export class SourceRootAdapter<TEntity extends Entity> extends Vue implements So
 
     get value(): TEntity {
     	return this.entity;
+    }
+
+    get type(): SourceType {
+    	return this.entity.meta.type.jstype;
+    }
+
+    get isList(): boolean {
+    	return false;
     }
 
     get displayValue(): string {


### PR DESCRIPTION
In some cases a source adapter may become invalid, ex: its parent is an item that was removed from a list, its parent is a property or path that has become null. This could cause errors in some properties such as `value` and `property`, which a caller would not be able to handle with simple null checks.

Previously, source path adapters used the value of its parent to obtain its property and value. This PR adds a concept of a `type` to source adapters, so that the path adapter can instead delegate to its parent to determine the containing type of its property or path, which may be based on the value of its parent if it has a value or fall back to static type information otherwise. Also added a null check in the `value` property to return if its parent does not have a value.