### PR TITLE
Allow any object (i.e. non-string) to be considered a source adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [Unreleased]
+### Changed
+- Allow any object (i.e. non-string) to be considered a source adapter
+### Fixed
+- Update SourceAdapter interfaces to be more accurate
+## Added
+- Provide isSource_X_Adapter functions to allow testing for each type
+
 ## [0.8.2] - 2022-10-20
 ### Fixed
 - ensure arrays are made observable to vue

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
-        "@cognitoforms/model.js": "^0.8.0",
+        "@cognitoforms/model.js": "^0.8.44",
         "vue": "^2.6.10",
         "vue-class-component": "^7.0.1",
         "vue-property-decorator": "^7.3.0"
@@ -1013,9 +1013,9 @@
       }
     },
     "node_modules/@cognitoforms/model.js": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@cognitoforms/model.js/-/model.js-0.8.0.tgz",
-      "integrity": "sha512-r00XidUOEp+xEBIazFqjnDBJB2Jo9CtSZsCsv1sIJyHY4SeCqCscTLANdgkrKk3caft2aKBCHcUsH8zsCSEe1Q=="
+      "version": "0.8.44",
+      "resolved": "https://registry.npmjs.org/@cognitoforms/model.js/-/model.js-0.8.44.tgz",
+      "integrity": "sha512-xz018xMPzOOmAA78+FbEbmUoC946rLj6WAFg/ASAbLXPv1sFYmSsYMHRtC5F2AjaEHU+JXa5nMi0hFgJ6a3GiA=="
     },
     "node_modules/@iarna/toml": {
       "version": "2.2.5",
@@ -14872,9 +14872,9 @@
       }
     },
     "@cognitoforms/model.js": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@cognitoforms/model.js/-/model.js-0.8.0.tgz",
-      "integrity": "sha512-r00XidUOEp+xEBIazFqjnDBJB2Jo9CtSZsCsv1sIJyHY4SeCqCscTLANdgkrKk3caft2aKBCHcUsH8zsCSEe1Q=="
+      "version": "0.8.44",
+      "resolved": "https://registry.npmjs.org/@cognitoforms/model.js/-/model.js-0.8.44.tgz",
+      "integrity": "sha512-xz018xMPzOOmAA78+FbEbmUoC946rLj6WAFg/ASAbLXPv1sFYmSsYMHRtC5F2AjaEHU+JXa5nMi0hFgJ6a3GiA=="
     },
     "@iarna/toml": {
       "version": "2.2.5",
@@ -18713,24 +18713,28 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
+          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
+          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -18741,12 +18745,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
+          "integrity": "sha512-9Y0g0Q8rmSt+H33DfKv7FOc3v+iRI+o1lbzt8jGcIosYW37IIW/2XVYq5NPdmaD5NQ59Nk26Kl/vZbwW9Fr8vg==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -18757,36 +18763,42 @@
         },
         "chownr": {
           "version": "1.1.1",
+          "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
+          "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
+          "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
+          "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
+          "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -18796,24 +18808,28 @@
         },
         "deep-extend": {
           "version": "0.6.0",
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
+          "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
+          "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -18823,12 +18839,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
+          "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
+          "integrity": "sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -18845,6 +18863,7 @@
         },
         "glob": {
           "version": "7.1.3",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -18859,12 +18878,14 @@
         },
         "has-unicode": {
           "version": "2.0.1",
+          "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -18874,6 +18895,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -18883,6 +18905,7 @@
         },
         "inflight": {
           "version": "1.0.6",
+          "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -18893,18 +18916,21 @@
         },
         "inherits": {
           "version": "2.0.3",
+          "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
+          "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -18914,12 +18940,14 @@
         },
         "isarray": {
           "version": "1.0.0",
+          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -18929,12 +18957,14 @@
         },
         "minimist": {
           "version": "0.0.8",
+          "integrity": "sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "minipass": {
           "version": "2.3.5",
+          "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -18945,6 +18975,7 @@
         },
         "minizlib": {
           "version": "1.2.1",
+          "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -18954,6 +18985,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
+          "integrity": "sha512-SknJC52obPfGQPnjIkXbmA6+5H15E+fR+E4iR2oQ3zzCLbd7/ONua69R/Gw7AgkTLsRG+r5fzksYwWe1AgTyWA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -18963,12 +18995,14 @@
         },
         "ms": {
           "version": "2.0.0",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.2.4",
+          "integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -18980,6 +19014,7 @@
         },
         "node-pre-gyp": {
           "version": "0.10.3",
+          "integrity": "sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -18998,6 +19033,7 @@
         },
         "nopt": {
           "version": "4.0.1",
+          "integrity": "sha512-+5XZFpQZEY0cg5JaxLwGxDlKNKYxuXwGt8/Oi3UXm5/4ymrJve9d2CURituxv3rSrVCGZj4m1U1JlHTdcKt2Ng==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -19008,12 +19044,14 @@
         },
         "npm-bundled": {
           "version": "1.0.5",
+          "integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.2.0",
+          "integrity": "sha512-7Mni4Z8Xkx0/oegoqlcao/JpPCPEMtUvsmB0q7mgvlMinykJLSRTYuFqoQLYgGY8biuxIeiHO+QNJKbCfljewQ==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -19024,6 +19062,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -19036,18 +19075,21 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
+          "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
+          "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
+          "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -19057,18 +19099,21 @@
         },
         "os-homedir": {
           "version": "1.0.2",
+          "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
+          "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -19079,18 +19124,21 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
+          "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -19103,6 +19151,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
+              "integrity": "sha512-7Wl+Jz+IGWuSdgsQEJ4JunV0si/iMhg42MnQQG6h1R6TNeVenp4U9x5CC5v/gYqz/fENLQITAWXidNtVL0NNbw==",
               "bundled": true,
               "dev": true,
               "optional": true
@@ -19111,6 +19160,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -19126,6 +19176,7 @@
         },
         "rimraf": {
           "version": "2.6.3",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -19135,42 +19186,49 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.6.0",
+          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
+          "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
+          "integrity": "sha512-meQNNykwecVxdu1RlYMKpQx4+wefIYpmxi6gexo/KAbwquJrBUrBmKYJrE8KFkVQAAVWEnwNdu21PgrD77J3xA==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "string_decoder": {
           "version": "1.1.1",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -19180,6 +19238,7 @@
         },
         "string-width": {
           "version": "1.0.2",
+          "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -19191,6 +19250,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
+          "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -19200,12 +19260,14 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
+          "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
+          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -19221,12 +19283,14 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
+          "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
+          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -19236,12 +19300,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
+          "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "yallist": {
           "version": "3.0.3",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "bundled": true,
           "dev": true,
           "optional": true

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "webpack-cli": "^3.3.0"
   },
   "dependencies": {
-    "@cognitoforms/model.js": "^0.8.0",
+    "@cognitoforms/model.js": "^0.8.44",
     "vue": "^2.6.10",
     "vue-class-component": "^7.0.1",
     "vue-property-decorator": "^7.3.0"

--- a/src/source-adapter.ts
+++ b/src/source-adapter.ts
@@ -17,13 +17,15 @@ export interface SourceAdapterOverrides {
 
 export interface SourceAdapter<TValue> {
 	readonly: boolean;
-    value: TValue;
-    displayValue: string;
-	type: SourceType;
-	isList: boolean;
+    readonly value: TValue;
+    readonly displayValue: string;
+	readonly type: SourceType;
+	readonly isList: boolean;
 }
 
 export interface SourcePropertyAdapter<TValue> extends SourceAdapter<TValue> {
+    value: TValue;
+    displayValue: string;
     readonly label: string;
 	readonly helptext: string;
 	readonly property: PropertyPath;
@@ -31,16 +33,28 @@ export interface SourcePropertyAdapter<TValue> extends SourceAdapter<TValue> {
     readonly options: SourceOptionAdapter<TValue>[];
 }
 
-export function isSourceAdapter(obj: any): obj is SourceRootAdapter<Entity> | SourcePathAdapter<Entity, any> | SourceItemAdapter<Entity, any> | SourceAdapter<Entity> {
-	if (obj instanceof SourceRootAdapter) return true;
-	if (obj instanceof SourcePathAdapter) return true;
-	if (obj instanceof SourceItemAdapter) return true;
-	if (typeof obj === "object") return true;
+export function isSourceRootAdapter(obj: any): obj is SourceRootAdapter<Entity> {
+	return obj instanceof SourceRootAdapter;
+}
+
+export function isSourcePathAdapter(obj: any): obj is SourcePathAdapter<Entity, any> {
+	return obj instanceof SourcePathAdapter;
+}
+
+export function isSourceItemAdapter(obj: any): obj is SourceItemAdapter<Entity, any> {
+	return obj instanceof SourceItemAdapter;
+}
+
+export function isSourceAdapter(obj: any, allowAnyObject: boolean = true): obj is SourceAdapter<Entity> {
+	if (isSourceRootAdapter(obj)) return true;
+	if (isSourcePathAdapter(obj)) return true;
+	if (isSourceItemAdapter(obj)) return true;
+	if (allowAnyObject && typeof obj === "object") return true;
 	return false;
 }
 
-export function isSourcePropertyAdapter(obj: any): obj is SourcePathAdapter<Entity, any> {
-	if (obj instanceof SourcePathAdapter) return true;
+export function isSourcePropertyAdapter(obj: any): obj is SourcePropertyAdapter<any> {
+	if (isSourcePathAdapter(obj)) return true;
 	return false;
 }
 

--- a/src/source-adapter.ts
+++ b/src/source-adapter.ts
@@ -31,10 +31,11 @@ export interface SourcePropertyAdapter<TValue> extends SourceAdapter<TValue> {
     readonly options: SourceOptionAdapter<TValue>[];
 }
 
-export function isSourceAdapter(obj: any): obj is SourceRootAdapter<Entity> | SourcePathAdapter<Entity, any> | SourceItemAdapter<Entity, any> {
+export function isSourceAdapter(obj: any): obj is SourceRootAdapter<Entity> | SourcePathAdapter<Entity, any> | SourceItemAdapter<Entity, any> | SourceAdapter<Entity> {
 	if (obj instanceof SourceRootAdapter) return true;
 	if (obj instanceof SourcePathAdapter) return true;
 	if (obj instanceof SourceItemAdapter) return true;
+	if (typeof obj === "object") return true;
 	return false;
 }
 

--- a/src/source-adapter.ts
+++ b/src/source-adapter.ts
@@ -16,7 +16,7 @@ export interface SourceAdapterOverrides {
 }
 
 export interface SourceAdapter<TValue> {
-	readonly: boolean;
+	readonly readonly: boolean;
     readonly value: TValue;
     readonly displayValue: string;
 	readonly type: SourceType;

--- a/src/source-adapter.ts
+++ b/src/source-adapter.ts
@@ -17,20 +17,20 @@ export interface SourceAdapterOverrides {
 
 export interface SourceAdapter<TValue> {
 	readonly readonly: boolean;
-    readonly value: TValue;
-    readonly displayValue: string;
+	readonly value: TValue;
+	readonly displayValue: string;
 	readonly type: SourceType;
 	readonly isList: boolean;
 }
 
 export interface SourcePropertyAdapter<TValue> extends SourceAdapter<TValue> {
-    value: TValue;
-    displayValue: string;
-    readonly label: string;
+	value: TValue;
+	displayValue: string;
+	readonly label: string;
 	readonly helptext: string;
 	readonly property: PropertyPath;
 	readonly lastTarget: Entity;
-    readonly options: SourceOptionAdapter<TValue>[];
+	readonly options: SourceOptionAdapter<TValue>[];
 }
 
 export function isSourceRootAdapter(obj: any): obj is SourceRootAdapter<Entity> {

--- a/src/source-option-adapter.ts
+++ b/src/source-option-adapter.ts
@@ -21,7 +21,7 @@ export class SourceOptionAdapter<TValue> extends Vue {
     get label(): string {
     	return this.parent.label;
     }
-    
+
     get displayValue(): string {
     	return formatDisplayValue(this.parent, this.value);
     }

--- a/src/source-path-mixin.ts
+++ b/src/source-path-mixin.ts
@@ -1,6 +1,6 @@
 import Vue from "vue";
 import { Component, Prop, Watch } from "vue-property-decorator";
-import { SourceAdapter, isSourceAdapter, hasOverrideValue, isSourcePropertyAdapter } from "./source-adapter";
+import { SourceAdapter, isSourceAdapter, hasOverrideValue, isSourcePathAdapter } from "./source-adapter";
 import { SourcePathAdapter, SourcePathOverrides } from "./source-path-adapter";
 import { Entity } from "@cognitoforms/model.js";
 
@@ -53,12 +53,12 @@ export class SourcePathMixin extends Vue implements SourcePathOverrides {
 
 	ensureOverridesAppliedToSourceAdapter(source: SourceAdapter<any>): void {
 		let hasOverrides = hasOverrideValue(this.label, String) || hasOverrideValue(this.helptext, String) || hasOverrideValue(this.readonly, Boolean) || hasOverrideValue(this.required, Boolean);
-		if (isSourcePropertyAdapter(source)) {
+		if (isSourcePathAdapter(source)) {
 			if (hasOverrides) {
 				if (source.overrides && source.overrides !== this) {
 					throw new Error("Overrides have already been applied to source of type '" + source.constructor.name + "'.");
 				}
-	
+
 				// Apply the given overrides as the overrides for the source
 				source.overrides = this;
 			}

--- a/src/source-path-mixin.unit.js
+++ b/src/source-path-mixin.unit.js
@@ -28,7 +28,7 @@ const Field = {
 
 const RootComponent = {
 	components: { Field },
-	props: ['nameRequired'],
+	props: ["nameRequired"],
 	template: `
 <Field source="FirstName" :required="nameRequired" v-slot="{ field }">
 	<div v-if="field.readonly"><span>{{ field.displayValue }}</span></div>
@@ -73,12 +73,12 @@ describe("SourcePathMixin", () => {
 		var fieldAdapter = fieldComponent.vm.$source;
 
 		expect(fieldAdapter.displayValue).toBe(person.FirstName);
-		expect(fieldComponent.classes().includes('c-required')).toBe(false);
+		expect(fieldComponent.classes().includes("c-required")).toBe(false);
 
 		fieldComponent.setProps({ required: true });
 		await Vue.nextTick();
 
 		expect(fieldAdapter.displayValue).toBe(person.FirstName);
-		expect(fieldComponent.classes().includes('c-required')).toBe(true);
+		expect(fieldComponent.classes().includes("c-required")).toBe(true);
 	});
 });

--- a/src/source-root-mixin.ts
+++ b/src/source-root-mixin.ts
@@ -1,6 +1,5 @@
 import Vue from "vue";
 import { Component, Prop, Watch } from "vue-property-decorator";
-import { SourceAdapter } from "./source-adapter";
 import { Entity } from "@cognitoforms/model.js";
 import { SourceRootAdapter } from "./source-root-adapter";
 import { observeEntity } from "./vue-model-observability";
@@ -18,7 +17,7 @@ export class SourceRootMixin extends Vue {
 		this.$source.readonly = readonly;
 	}
 
-	get $source(): SourceAdapter<Entity> {
+	get $source(): SourceRootAdapter<Entity> {
 		let entity: Entity;
 
 		if (this.source instanceof Entity) {


### PR DESCRIPTION
Typically string values are used as the `source` prop of source mixin components. However, you can pass in an actual source adapter object as well and it will be used as the `$source`. Relax the function to allow any object to be considered a source adapter, so that objects that conform to the source adapter "interface" can be used.